### PR TITLE
Fix Intellij IDEA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,9 @@ processResources
     }
 }
 
-sourceSets { main { output.resourcesDir = output.classesDir } }
+apply plugin: 'idea'
+idea {
+    module {
+        inheritOutputDirs = true
+    }
+}

--- a/src/main/java/com/brandon3055/brandonscore/BrandonsCore.java
+++ b/src/main/java/com/brandon3055/brandonscore/BrandonsCore.java
@@ -19,7 +19,7 @@ public class BrandonsCore
 {
 	public static final String MODNAME = "Brandon's Core";
     public static final String MODID = "BrandonsCore";
-    public static final String VERSION = "1.0.0.10";//MC Update, Major version, Minor Version, Release number (private or public)
+    public static final String VERSION = "1.0.0.11";//MC Update, Major version, Minor Version, Release number (private or public)
 
 	@Mod.Instance(BrandonsCore.MODID)
 	public static BrandonsCore instance;


### PR DESCRIPTION
The workaround for Intellij IDEA unfortunately breaks the build using other methods like `gradlew` from ForgeGradle. The results is that every file gets included twice into the final jar:

![intellijfix1](https://cloud.githubusercontent.com/assets/1928113/13906133/8f441238-eecf-11e5-8bfd-bfcf4ca2e8ac.png)
![intellijfix2](https://cloud.githubusercontent.com/assets/1928113/13906137/9b43fc06-eecf-11e5-8b7b-8df7280f60ac.png)

This breaks FML when booting, because of the duplicate `mcmod.info` file:
```
java.lang.IllegalArgumentException: Multiple entries with same key: BrandonsCore=FMLMod:BrandonsCore{1.0.0.10} and BrandonsCore=FMLMod:BrandonsCore{1.0.0.10}
```
See http://www.minecraftforge.net/forum/index.php/topic,21354.msg150001.html#msg150001

@brandon3055 I don't use IDEA, and therefore haven't tested the change. Please see if it still works as expected.
- - - 
Also fix `VERSION` field that prevented loading with Draconic Evolution 1.0.2 RC2.
